### PR TITLE
Handle non-JSON responses in API helper

### DIFF
--- a/server/web.py
+++ b/server/web.py
@@ -36,5 +36,6 @@ class Api:
                 print('Unable to process returned data')
                 self.statusCode = 500
                 self.res = None
+                return self.statusCode, self.res
 
         return self.statusCode, self.res

--- a/server/web.py
+++ b/server/web.py
@@ -36,6 +36,5 @@ class Api:
                 print('Unable to process returned data')
                 self.statusCode = 500
                 self.res = None
-                return self.statusCode, self.res
 
         return self.statusCode, self.res

--- a/server/web.py
+++ b/server/web.py
@@ -34,5 +34,7 @@ class Api:
                 self.res = response.json()
             except ValueError:
                 print('Unable to process returned data')
+                self.statusCode = 500
+                return self.statusCode, None
 
         return self.statusCode, self.res

--- a/server/web.py
+++ b/server/web.py
@@ -24,12 +24,15 @@ class Api:
                 response = requests.delete(self.url, headers=self.headers, json=self.data)
             else:
                 print('Unsupported method')
-        except:
+        except Exception:
             response = None
             print('Unable to access URL')
 
         if response is not None:
             self.statusCode = response.status_code
-            self.res = response.json()
+            try:
+                self.res = response.json()
+            except ValueError:
+                print('Unable to process returned data')
 
         return self.statusCode, self.res

--- a/server/web.py
+++ b/server/web.py
@@ -35,6 +35,6 @@ class Api:
             except ValueError:
                 print('Unable to process returned data')
                 self.statusCode = 500
-                return self.statusCode, None
+                self.res = None
 
         return self.statusCode, self.res


### PR DESCRIPTION
## Summary
- Restore original Api data default and remove extraneous package and test files
- Log a message when responses cannot be parsed as JSON

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c497a0a8dc8330b69c3dd9d11139e0