### PR TITLE
fix(onetrading): remove unintended stop cleanup

### DIFF
--- a/bot/logic.py
+++ b/bot/logic.py
@@ -4,7 +4,7 @@ def stop(parameters, crypto):
         parameters.database.putInActive(crypto)
         return "Unable to sell " + crypto.instrument_code + ".\n"
 
-    message = "Selling market order for " + crypto.instrument_code + " at " + str(round(crypto.current * parameters.account.takerFee, 2)) + "€"
+    message = "Selling limit order for " + crypto.instrument_code + " at " + str(round(crypto.current * parameters.account.takerFee, 2)) + "€"
 
     if crypto.current * parameters.account.takerFee >= crypto.placed:
         message += " (WON: " + str(round((crypto.current * parameters.account.takerFee) - crypto.placed, 2)) + "€)"
@@ -19,7 +19,7 @@ def start(parameters, crypto):
 
     parameters.account.available -= crypto.placed
 
-    return "Buying market order for " + crypto.instrument_code + \
+    return "Buying limit order for " + crypto.instrument_code + \
         " (OWNED: " + str(round(crypto.owned, crypto.precision)) + \
         " / PRICE: " + str(round(crypto.last_price, crypto.precision)) + \
         " / HIST: " + str(round(crypto.macd - crypto.signal, crypto.precision)) + \
@@ -49,9 +49,6 @@ def monitor(parameters, actives):
         elif parameters.min_profit > 1.0 and crypto.current * parameters.account.takerFee >= crypto.placed * parameters.min_profit:
             trading_message += crypto.instrument_code + " has reached its profit level. "
             trading_message += stop(parameters, crypto)
-
-        elif crypto.higher * parameters.min_recovered > 10 and (crypto.higher == crypto.current or crypto.stop_id == ""):
-            parameters.exchange_client.stopLossOrder(crypto, parameters)
 
         if crypto.failed == True and crypto.alerted == False:
             trading_alert += "No action can be done on " + crypto.instrument_code + " due to an error.\n"

--- a/server/exchanges/history.py
+++ b/server/exchanges/history.py
@@ -214,9 +214,6 @@ class Exchange:
 
         return profitable_assets
 
-    def stopLossOrder(self, crypto, parameters):
-        return True
-
     def sellingMarketOrder(self, crypto, parameters):
         parameters.database.putInHistory(crypto)
         parameters.account.available += crypto.current * parameters.account.takerFee

--- a/server/exchanges/onetrading.py
+++ b/server/exchanges/onetrading.py
@@ -592,70 +592,12 @@ class Exchange:
 
         return profitable_assets
 
-    def stopLossOrder(self, crypto, parameters):
-        # We comment this code base to keep logic for later when onetrading eventually brings back stop order
-
-        # if crypto.stop_id != "":
-        #     status_code, data = web.Api(Exchange.baseUrl + "/account/orders/" + crypto.stop_id, headers=self.headers, method="DELETE").send()
-        #     time.sleep(1)
-
-        #     if status_code == 429:
-        #         print("Too many requests at once")
-        #         return False
-
-        #     if status_code != 204:
-        #         print("Error while trying to cancel stop order")
-        #         return False
-
-        #     crypto.stop_id = ""
-        #     parameters.database.putInActive(crypto)
-
-        # body = {
-        #     "instrument_code": crypto.instrument_code,
-        #     "side": "SELL",
-        #     "type": "STOP",
-        #     "amount": self.truncate(crypto.owned, crypto.precision),
-        #     "price": self.truncate(crypto.higher * parameters.security_min_recovered / crypto.owned, 2),
-        #     "trigger_price": self.truncate(crypto.higher * parameters.security_min_recovered / crypto.owned, 2)
-        # }
-
-        # status_code, data = web.Api(Exchange.baseUrl + "/account/orders", headers=self.headers, method="POST", data=body).send()
-        # time.sleep(1)
-
-        # if status_code == 429:
-        #     print("Too many requests at once")
-        #     return False
-
-        # if status_code != 201:
-        #     crypto.failed == True
-        #     print("Error while trying to create stop order")
-        #     return False
-
-        # crypto.stop_id = data["order_id"]
-
-        # parameters.database.putInActive(crypto)
-
-        return True
-
     def sellingMarketOrder(self, crypto, parameters):
-        # if crypto.stop_id != "":
-        #     status_code, data = web.Api(Exchange.baseUrl + "/account/orders/" + crypto.stop_id, headers=self.headers, method="DELETE").send()
-        #     time.sleep(1)
-
-        #     if status_code == 429:
-        #         print("Too many requests at once")
-        #         return False
-
-        #     if status_code != 204:
-        #         print("Error while trying to cancel stop order")
-        #         return False
-
-        #     crypto.stop_id = ""
-        #     parameters.database.putInActive(crypto)
-
         current_price = self.getPrice(crypto.instrument_code)
         if current_price == 0:
             return False
+
+        limitPrice = self.truncate(current_price * 0.75, 2)
 
         body = {
             "instrument_code": crypto.instrument_code,
@@ -663,7 +605,7 @@ class Exchange:
             "type": "LIMIT",
             "time_in_force": "IMMEDIATE_OR_CANCELLED",
             "amount": self.truncate(crypto.owned, crypto.precision),
-            "price": current_price * 0.75
+            "price": limitPrice
         }
 
         status_code, data = web.Api(Exchange.baseUrl + "/account/orders", headers=self.headers, method="POST", data=body).send()
@@ -688,13 +630,14 @@ class Exchange:
             return False
 
         amount = ((parameters.account.available / crypto.danger) * 0.99) / current_price
+        limitPrice = self.truncate(current_price * 1.25, 2)
         body = {
             "instrument_code": crypto.instrument_code,
             "side": "BUY",
             "type": "LIMIT",
             "time_in_force": "IMMEDIATE_OR_CANCELLED",
             "amount": self.truncate(amount, crypto.precision),
-            "price": current_price * 1.25
+            "price": limitPrice
         }
 
         status_code, data = web.Api(Exchange.baseUrl + "/account/orders", headers=self.headers, method="POST", data=body).send()

--- a/server/exchanges/paper_trading.py
+++ b/server/exchanges/paper_trading.py
@@ -391,9 +391,6 @@ class Exchange:
 
         return profitable_assets
 
-    def stopLossOrder(self, crypto, parameters):
-        return True
-
     def sellingMarketOrder(self, crypto, parameters):
         parameters.database.putInHistory(crypto)
         parameters.account.available += crypto.current * parameters.account.takerFee


### PR DESCRIPTION
## Summary
- remove the mistakenly revived stop order cancellation logic from the OneTrading sell flow while keeping the limit pricing

## Testing
- python -m compileall server/exchanges/onetrading.py

------
https://chatgpt.com/codex/tasks/task_e_68ed3d01511c8330bbea68a111917f84